### PR TITLE
Remove ODE requirement

### DIFF
--- a/yaml2sbml/yaml_schema.yaml
+++ b/yaml2sbml/yaml_schema.yaml
@@ -195,6 +195,3 @@ properties:
         - conditionId
 
 additionalProperties: false
-
-required:
-  - odes


### PR DESCRIPTION
Not sure if there were other reasons to have this, apart from the expectation that the package is used for ODEs.

#142 